### PR TITLE
add a proxy activity for departures shortcut

### DIFF
--- a/sthlmtraveling/src/main/AndroidManifest.xml
+++ b/sthlmtraveling/src/main/AndroidManifest.xml
@@ -214,6 +214,14 @@
 
         </activity>
 
+        <activity
+            android:name=".DeparturesShortcutProxyActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <receiver
             android:name=".receivers.OnBootReceiver"
             android:enabled="true"

--- a/sthlmtraveling/src/main/java/com/markupartist/sthlmtraveling/DeparturesShortcutProxyActivity.java
+++ b/sthlmtraveling/src/main/java/com/markupartist/sthlmtraveling/DeparturesShortcutProxyActivity.java
@@ -1,0 +1,38 @@
+package com.markupartist.sthlmtraveling;
+
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.app.TaskStackBuilder;
+import android.support.v7.app.AppCompatActivity;
+
+public class DeparturesShortcutProxyActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+
+        Intent startIntent = new Intent(getApplicationContext(), StartActivity.class);
+        if (!intent.hasExtra(DeparturesActivity.EXTRA_SITE_NAME)) {
+            startActivity(startIntent);
+        }
+
+        Intent departuresIntent = new Intent(getApplicationContext(), DeparturesActivity.class);
+        departuresIntent.putExtra(DeparturesActivity.EXTRA_SITE_NAME,
+                intent.getStringExtra(DeparturesActivity.EXTRA_SITE_NAME));
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            startActivity(departuresIntent);
+        } else {
+            Intent[] pendingIntents =
+                    TaskStackBuilder.create(this)
+                            .addNextIntentWithParentStack(startIntent)
+                            .addNextIntentWithParentStack(departuresIntent)
+                            .getIntents();
+            startActivities(pendingIntents);
+        }
+
+    }
+}

--- a/sthlmtraveling/src/main/java/com/markupartist/sthlmtraveling/SearchDeparturesFragment.java
+++ b/sthlmtraveling/src/main/java/com/markupartist/sthlmtraveling/SearchDeparturesFragment.java
@@ -253,7 +253,7 @@ public class SearchDeparturesFragment extends BaseListFragment implements Adapte
     private void onCreateShortCut(Site stop) {
         // Setup the intent to be launched
         Intent shortcutIntent = new Intent(getActivity()
-                .getApplicationContext(), DeparturesActivity.class);
+                .getApplicationContext(), DeparturesShortcutProxyActivity.class);
         shortcutIntent.setAction(Intent.ACTION_VIEW);
         shortcutIntent.putExtra(DeparturesActivity.EXTRA_SITE_NAME, stop.getName());
         shortcutIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);


### PR DESCRIPTION
Detta fixar backåt stackens beteende från departures-genvägen, dvs. upp-pilen går till StartActivity. Detta för ny skapande genvägar. För redan existerande genvägar gör det ingen skillnad.

Man skulle förmodligen kunna fixa existerande genvänar också, dock har jag inte tittat någont på det än iaf.