### PR TITLE
remove touch feedback from departure listitems

### DIFF
--- a/sthlmtraveling/src/main/res/layout/departures_row.xml
+++ b/sthlmtraveling/src/main/res/layout/departures_row.xml
@@ -20,7 +20,7 @@
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/listPreferredItemHeight"
-                android:background="?attr/selectableItemBackground"
+                android:background="@color/background"
     >
 
     <TextView


### PR DESCRIPTION
`android:background` seems to be defined by the theme, so just not
setting it makes no difference. Setting it to background color makes for
the expected visual result, ie. no feedback.